### PR TITLE
fix(generate): accumulate tokens across networks

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -65,16 +65,16 @@ def generate_tokenlist(
     display_summary(networks, tokens_in_folder, tokens_to_add)
 
     all_failed_tokens = {}
-    processed_tokens = []
+    all_processed_tokens = []
 
     for network in networks:
         processed_tokens, _ = process_network(network, existing_tokenlist, all_failed_tokens)
         ensure_native_token_in_list(processed_tokens, network)
 
-        processed_tokens.extend(processed_tokens)
+        all_processed_tokens.extend(processed_tokens)
 
     # Update the tokenlist after processing all networks
-    updated_tokenlist = update_tokenlist(processed_tokens, existing_tokenlist)
+    updated_tokenlist = update_tokenlist(all_processed_tokens, existing_tokenlist)
 
     # Check if there are any failed tokens
     if all_failed_tokens:


### PR DESCRIPTION
## The bug

`generate_tokenlist` reassigns `processed_tokens` inside the network loop, then extends that list with itself:

```python
    all_failed_tokens = {}
    processed_tokens = []

    for network in networks:
        processed_tokens, _ = process_network(network, existing_tokenlist, all_failed_tokens)
        ensure_native_token_in_list(processed_tokens, network)

        processed_tokens.extend(processed_tokens)

    # Update the tokenlist after processing all networks
    updated_tokenlist = update_tokenlist(processed_tokens, existing_tokenlist)
```

Each iteration **replaces** the previous network's results instead of adding to them, so only the last network reaches `update_tokenlist`. Two smaller things fall out of the same lines: the `processed_tokens = []` above the loop is dead, and `processed_tokens.extend(processed_tokens)` duplicates the current network's entries (harmless downstream only because `update_tokenlist` re-keys on `chainId_address`).

## Why it matters

`upkeep.py all_networks` passes every configured network:

```python
if network == "all_networks":
    networks_to_include = [net for net in NETWORKS.keys() if net != "assets-harmony"]
```

So a full run does the per-network work for all ~35 of them, then uploads a list built from only the last one. Tokens already published on GitHub Pages survive through the `existing_tokens + new_tokens` merge, which is what makes this quiet: **newly added icons for every network except the last are silently dropped**, and the run still prints `All tokens processed successfully!`.

## Reproduction

Patching only the collaborators (`scan_images_folder`, `process_network`) so the real `generate_tokenlist` runs offline, with one token per network:

```
networks processed : ['assets-arbitrum', 'assets-base', 'assets-optimism']
tokens in output   : ['assets-optimism']
missing networks   : ['assets-arbitrum', 'assets-base']
```

After this change:

```
networks processed : ['assets-arbitrum', 'assets-base', 'assets-optimism']
tokens in output   : ['assets-arbitrum', 'assets-base', 'assets-optimism']
missing networks   : []
```

## The fix

Accumulate into a separate list and pass that to `update_tokenlist`. Three lines, no behaviour change for the single-network path that `generate_list.py` uses.

`black --check` and `isort --check-only` pass on the changed file. The repo has no test suite or Python CI, so I left the reproduction here rather than adding pytest and a test job onto a bug fix — happy to add tests if you'd like them.

## Unrelated, while I was in here

`git clone` warns on this repo because two files differ only in case:

```
images/assets-celo/0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e.png
images/assets-celo/0x48065fbbe25f71c9282ddf5e1cd6d6a887483d5e.png
```

On macOS/Windows checkouts only one of the two survives. `pr-checks.yml` requires new icons to be lowercase, so the mixed-case one looks like it predates that rule. It is the only such pair in the repo. Left alone here to keep this diff to the one fix — say the word and I'll send a follow-up deleting it.
