### PR TITLE
fix(ci): list changed files via the API instead of checking out the fork

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,15 +14,26 @@ jobs:
   changed_files:
     runs-on: ubuntu-latest
     name: PR automated checks
+    if: github.event_name == 'pull_request_target'
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
-
+      # Read the changed filenames from the API rather than checking out the
+      # head repository. This job runs under `pull_request_target`, so a
+      # checkout of `head.repo.full_name` fetches fork-controlled code into a
+      # context that holds the base repo's token, secrets and
+      # `pull-requests: write` — the "pwn request" pattern that
+      # `actions/checkout` now refuses outright, which is why this job has been
+      # failing at its first step on every fork PR. Only the file list is
+      # needed here, and the API supplies it without fetching fork content.
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename' | tr '\n' ' ')
+          echo "Changed files: $files"
+          echo "all_changed_files=$files" >> $GITHUB_OUTPUT
 
       - name: Process changed files
         id: changes-errors


### PR DESCRIPTION
## The bug

`pr-checks` runs on `pull_request_target` and checks out the head repository:

```yaml
- uses: actions/checkout@v4
  with:
    repository: ${{ github.event.pull_request.head.repo.full_name }}
```

`actions/checkout` now refuses that combination outright:

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
This workflow runs with the base repository's GITHUB_TOKEN, secrets,
default-branch cache scope, and runner access. Fetching and executing a fork's
code in that trusted context commonly leads to "pwn request" vulnerabilities.
```

So the job dies on its **first step** for every fork PR, before any icon validation runs. Same-repo branches still pass — which is why this has been easy to miss — but forks are the overwhelming majority of PRs to this repo, so in practice the PNG-only and lowercase-filename checks have stopped running for exactly the contributors they exist for.

Two current examples, both failing at checkout with that message rather than on anything about their contents:

- [`add-jrdola`](https://github.com/curvefi/curve-assets/actions/runs/32847931270) (Aug 25, an icon submission)
- my own #1085

## Why not just re-enable the checkout

`allow-unsafe-pr-checkout: true` would turn the job green again by reintroducing the vulnerability the refusal exists to prevent — fork-controlled content fetched into a context that holds the base repo's token, its secrets, and `pull-requests: write`. The refusal is correct; the workflow is what should change.

## The fix

Nothing in this job needs the fork's contents. Every step operates on the *list of changed filenames* — the path prefix check, the `.png` check, the lowercase-filename regex. `GET /repos/{owner}/{repo}/pulls/{number}/files` supplies that list with no checkout at all, so no fork content is ever fetched or executed and the trusted context stays clean.

Two things fall out of it:

- The dependency on `tj-actions/changed-files` goes away. Its `v42` tag was among those affected by the [March 2025 supply-chain compromise](https://github.com/tj-actions/changed-files/issues/2463), and it was only present here because it needed a working tree.
- The job is now guarded on `pull_request_target`, since the `workflow_dispatch` trigger carries no `pull_request` payload and could not have produced a file list.

The downstream steps are untouched — same `all_changed_files` output name, same space-separated shape, same validation logic.

## Test plan

`pr-checks.yml` parses, and the job no longer references `actions/checkout` or `tj-actions`:

```
YAML valid
job if     : github.event_name == 'pull_request_target'
steps      : ['Get changed files', 'Process changed files', 'Check if errors', 'Comment on PR if error', 'Exit with error']
checkout   : False
tj-actions : False
```

Because `pull_request_target` workflows run from the **base** branch, this change cannot be exercised by its own PR — it takes effect for PRs opened after it merges. The first fork PR afterwards should show the job reaching "Process changed files" instead of erroring at checkout.

Sent separately from #1085 (a token-list generation fix) since the two are unrelated.
